### PR TITLE
fix file descriptor NULL check on greek_read

### DIFF
--- a/08_unicode/greek_read01.c
+++ b/08_unicode/greek_read01.c
@@ -11,7 +11,7 @@ int main()
 	wchar_t line[length];
 
 	fp = fopen(file,"r");
-	if( file==NULL )
+	if( fp==NULL )
 	{
 		fprintf(stderr,"Unable to open %s\n",file);
 		exit(1);

--- a/08_unicode/greek_read02.c
+++ b/08_unicode/greek_read02.c
@@ -10,7 +10,7 @@ int main()
 	wint_t ch;
 
 	fp = fopen(file,"r");
-	if( file==NULL )
+	if( fp==NULL )
 	{
 		fprintf(stderr,"Unable to open %s\n",file);
 		exit(1);


### PR DESCRIPTION
This PR fixes the NULL check on file descriptor after `fopen()`