### PR TITLE
nato05.c example printing out NULL values(s)

### DIFF
--- a/03_nato/nato05.c
+++ b/03_nato/nato05.c
@@ -69,7 +69,8 @@ int main(int argc, char *argv[])
 			if( offset > 0 )
 			{
 				word[offset] = '\0';
-				putchar( isterm(word) );
+				if ( (ch = isterm(word)) != '\0') 
+                    putchar( ch );
 				offset=0;
 			}
 		}


### PR DESCRIPTION
missing if check. Currently the code is printing out NULL ('\0') returned from isterm function.