### PR TITLE
improvements to exercise 5.4

### DIFF
--- a/05_encoding/urldecoder02.c
+++ b/05_encoding/urldecoder02.c
@@ -37,6 +37,10 @@ int main()
 				putchar(ch);
 			else if(isalnum(ch))	/* include the ctype.h header file */
 				putchar(ch);
+            else if(ch=='+')  /* alternative space representation */
+                putchar(' ');
+            else if(ch==10)   /* linefeed */
+                break;
 			else
 			{
 				/* bail on illegal character */

--- a/05_encoding/urldecoder02.c
+++ b/05_encoding/urldecoder02.c
@@ -39,7 +39,7 @@ int main()
 				putchar(ch);
             else if(ch=='+')  /* alternative space representation */
                 putchar(' ');
-            else if(ch==10)   /* linefeed */
+            else if(ch==10) /* linefeed */
                 break;
 			else
 			{

--- a/05_encoding/urldecoder02.c
+++ b/05_encoding/urldecoder02.c
@@ -37,10 +37,10 @@ int main()
 				putchar(ch);
 			else if(isalnum(ch))	/* include the ctype.h header file */
 				putchar(ch);
-            else if(ch=='+')  /* alternative space representation */
-                putchar(' ');
-            else if(ch==10) /* linefeed */
-                break;
+                        else if(ch=='+')  /* alternative space representation */
+                                putchar(' ');
+                        else if(ch==10) /* linefeed */
+                                break;
 			else
 			{
 				/* bail on illegal character */


### PR DESCRIPTION
Made improvements to exercise 5.4 code sample you may want to consider merging. 

Previous example in book in section 5.3.2 shows + as space as there are two ways to represent it. As such, this should be considered in exercise 5.4 code sample I think. 

In addition, when entering all the text to decode and press return key, it outputs at the end the invalid message. 
I added linefeed check so that this message isn't printed and breaks the program instead as this indicates end of input I assume. 